### PR TITLE
[ARRCONN-225] Cannot insert when the modes is automatically generated

### DIFF
--- a/lib/schema/createModelsFromSchema.js
+++ b/lib/schema/createModelsFromSchema.js
@@ -12,15 +12,17 @@ exports.createModelsFromSchema = function () {
 		var object = self.schema.objects[modelName],
 			fields = {};
 
+
+		
 		Object.keys(object).forEach(function (fieldName) {
-			if (fieldName !== 'id') {
+			if (!fieldName.match(/id/i)) { // replace fieldName !== 'id'
 				fields[fieldName] = {
 					type: self.convertDataTypeToJSType(object[fieldName].DATA_TYPE),
 					required: object.NULLABLE === 'N'
 				};
 			}
 		});
-
+		
 		models[self.name + '/' + modelName] = Arrow.Model.extend(self.name + '/' + modelName, {
 			name: self.name + '/' + modelName,
 			autogen: !!self.config.modelAutogen,


### PR DESCRIPTION
The check that strips the "id" field from the generated model, was not case insensitive.
