### PR TITLE
[ARRCONN-235] Dependencies not working properly on macOS Sierra 10.12.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
 	// Test Setup
 	grunt.registerTask('createTestData', function () {
 		var cb = this.async(),
-			config = require('./conf/default').connectors['appc.oracledb'],
+			config = require('./conf/local').connectors['appc.oracledb'],
 			OracleDB = require('oracledb');
 		OracleDB.getConnection(config, function (err, connection) {
 			if (err) {

--- a/README.md
+++ b/README.md
@@ -1,66 +1,64 @@
-# Oracle Connector
+# Oracle Database Connector
 
 This is an Arrow connector to Oracle Database.
 
+## Prerequisites
+
+This connector requires Oracle Instant Client.
+
+To install it, follow the steps described here: https://github.com/oracle/node-oracledb/blob/master/INSTALL.md#instosx
+
 ## Installation
 
-You need to have the Oracle instant client installed on your computer in /opt/oracle/instantclient/
-
-https://github.com/oracle/node-oracledb/blob/master/INSTALL.md#instosx
-
-Then, use the connector in your project:
+To install the connector use:
 
 ```bash
 $ appc install connector/appc.oracledb --save
 ```
 
-## Usage
+## Configuration
 
-Reference the connector in your model.
+Create appc.oracledb.default.js in `<your_project>/conf` directory.
 
+Example appc.oracledb.defaults.js content:
 ```javascript
-var Account = Arrow.Model.extend('Account', {
-	fields: {
-		Name: { type: String, required: true, validator: /[a-zA-Z]{3,}/ }
-	},
-	connector: 'appc.oracledb'
-});
+module.exports = {
+    connectors: {
+        'appc.oracledb': {
+            // Your connection credentials.
+            user: 'hr',
+            password: 'welcome',
+            connectString: 'localhost/XE',
+            // Create models based on your schema that can be used in your API.
+            generateModelsFromSchema: true,
+            // Whether or not to generate APIs based on the methods in generated models.
+            modelAutogen: true
+        }
+    }
+};
 ```
 
-If you want to map a specific model to a specific table, use metadata.
-For example, to map the `account` model to the table `accounts`, set it such as:
+This example connector configuration will automatically generate models based on your database schema.
+If you want to create a custom model, set `generateModelsFromSchema: false` and reference the documentation for more information how to create models.
 
-```javascript
-var Account = Arrow.Model.extend('account', {
-	fields: {
-		Name: { type: String, required: false, validator: /[a-zA-Z]{3,}/ }
-	},
-	connector: 'appc.oracledb',
-	metadata: {
-		'appc.oracledb': {
-			table: 'accounts'
-		}
-	}
-});
-```
+## Unit Tests
 
-### Running Unit Tests
-
-The tests will automatically create their own table named "TEST_Post".
+Run the tests:
 
 ```bash
 npm test
 ```
 
+The tests will automatically create their own table named "TEST_Post".
+
 
 # Contributing
 
-This project is open source and licensed under the [Apache Public License (version 2)](http://www.apache.org/licenses/LICENSE-2.0).  Please consider forking this project to improve, enhance or fix issues. If you feel like the community will benefit from your fork, please open a pull request. 
+This project is open source and licensed under the [Apache Public License (version 2)](http://www.apache.org/licenses/LICENSE-2.0).  Please consider forking this project to improve, enhance or fix issues. If you feel like the community will benefit from your fork, please open a pull request.
 
-To protect the interests of the contributors, Appcelerator, customers and end users we require contributors to sign a Contributors License Agreement (CLA) before we pull the changes into the main repository. Our CLA is simple and straightforward - it requires that the contributions you make to any Appcelerator open source project are properly licensed and that you have the legal authority to make those changes. This helps us significantly reduce future legal risk for everyone involved. It is easy, helps everyone, takes only a few minutes, and only needs to be completed once. 
+To protect the interests of the contributors, Appcelerator, customers and end users we require contributors to sign a Contributors License Agreement (CLA) before we pull the changes into the main repository. Our CLA is simple and straightforward - it requires that the contributions you make to any Appcelerator open source project are properly licensed and that you have the legal authority to make those changes. This helps us significantly reduce future legal risk for everyone involved. It is easy, helps everyone, takes only a few minutes, and only needs to be completed once.
 
 [You can digitally sign the CLA](http://bit.ly/app_cla) online. Please indicate your email address in your first pull request so that we can make sure that will locate your CLA.  Once you've submitted it, you no longer need to send one for subsequent submissions.
-
 
 
 # Legal Stuff

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This is an Arrow connector to Oracle Database.
 
 ## Prerequisites
 
-This connector requires Oracle Instant Client.
+This connector requires Oracle Instant Client installed. To install it, please follow the instructions for your environment here:
+http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html
 
-To install it, follow the steps described here: https://github.com/oracle/node-oracledb/blob/master/INSTALL.md#instosx
+The connector also depends on the 'node-oracledb' module. To be able to properly install the connector, please check the prerequisites here:
+https://github.com/oracle/node-oracledb#-installation
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appc.oracledb",
   "description": "Oracle Database Connector",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Dawson Toth",
   "maintainers": [
     "Dawson Toth <dtoth@appcelerator.com>"
@@ -20,7 +20,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "lodash": "^3.10.1",
-    "oracledb": "^1.5.0",
+    "oracledb": "^1.11.0",
     "pkginfo": "^0.3.1",
     "semver": "^5.0.3"
   },

--- a/test/capabilities/connect.js
+++ b/test/capabilities/connect.js
@@ -1,7 +1,7 @@
 // jscs:disable jsDoc
 var _ = require('lodash');
 
-var goodConfig = require('../../conf/default').connectors['appc.oracledb'];
+var goodConfig = require('../../conf/local').connectors['appc.oracledb'];
 
 exports.connect = {
 	goodConfig: goodConfig,


### PR DESCRIPTION
  - oracledb npm package deps. - updated;
  - connector's readme.md updated;
  - default.js renamed to local.js in order of compatibility while testing with the other connectors;
  - version bumped

https://jira.appcelerator.org/browse/ARRCONN-235